### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ nodrew_embedly:
 
 ## Usage
 
-There are 3 client's that can be used. Each corrisponds to the Embedly endpoing of the same name:
+There are 3 client's that can be used. Each corresponds to the Embedly endpoing of the same name:
 
 - oEmbed:    nodrew_embedly.oembed.client
 - Preview:   nodrew_embedly.preview.client


### PR DESCRIPTION
@dbtlr, I've corrected a typographical error in the documentation of the [NodrewEmbedlyBundle](https://github.com/dbtlr/NodrewEmbedlyBundle) project. Specifically, I've changed corrispond to correspond. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
